### PR TITLE
copy background from existing contentView

### DIFF
--- a/JNWClipView.h
+++ b/JNWClipView.h
@@ -22,6 +22,9 @@
 // A NSClipView subclass with a buttery -scrollToRect: animation.
 @interface JNWClipView : NSClipView
 
+/// Initializes a new JNWClipView and copies over the attributes of a specific clipView
+- (instancetype)initWithClipView:(NSClipView *)clipView;
+
 // Calls -scrollRectToVisible:, optionally animated.
 //
 // If animated, the animation will be performed with an ease-out timing function.

--- a/JNWClipView.m
+++ b/JNWClipView.m
@@ -44,6 +44,15 @@ static const CGFloat JNWClipViewDecelerationRate = 0.78;
 
 @implementation JNWClipView
 
+- (instancetype)initWithClipView:(NSClipView *)clipView
+{
+    if (self = [self initWithFrame:clipView.frame]) {
+        self.backgroundColor = clipView.backgroundColor;
+        self.drawsBackground = clipView.drawsBackground;
+    }
+    return self;
+}
+
 - (instancetype)initWithFrame:(NSRect)frame {
 	self = [super initWithFrame:frame];
 	if (self == nil) return nil;

--- a/JNWScrollView.m
+++ b/JNWScrollView.m
@@ -54,7 +54,7 @@
 - (void)swapClipView {
 	self.wantsLayer = YES;
 	id documentView = self.documentView;
-	JNWClipView *clipView = [[JNWClipView alloc] initWithFrame:self.contentView.frame];
+    JNWClipView *clipView = [[JNWClipView alloc] initWithClipView:self.contentView];
 	self.contentView = clipView;
 	self.documentView = documentView;
 }


### PR DESCRIPTION
I noticed that when I tried to set translucent backgrounds on my JNWCollectionView that they seemed to be backed by a white layer. I tried various methods to make sure the scroll view wasn't opaque, but my debugging led me all the way down to the submodule of my project's submodule, so I figured I'd pull request from there.

Context: I'm using Xcode 6.1.1 and building for OS X 10.10
